### PR TITLE
cmd: improved `cache-clear` command

### DIFF
--- a/cmd/cache_clear.go
+++ b/cmd/cache_clear.go
@@ -1,15 +1,18 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
+
+	"github.com/i582/cfmt/cmd/cfmt"
 )
 
 func CacheClear() (int, error) {
 	cacheDir := DefaultCacheDir()
 	if cacheDir == "/" || cacheDir == "" {
-		panic(fmt.Sprintf("attempted to rm -rf %s", cacheDir))
+		cfmt.Printf("Cache clearing error: attempted to {{rm -rf %s}}::red", cacheDir)
+		return 2, nil
 	}
 	err := os.RemoveAll(cacheDir)
+	cfmt.Println("The cache has been {{successfully}}::green deleted.")
 	return 0, err
 }


### PR DESCRIPTION
**Type**: `refactoring`

Added a message about the successful deletion of the cache, and now, 
in case of a strange path, a message is displayed without panic.