### PR TITLE
cmd: added initial support of PHP 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## Unreleased
+
+Due to the addition of PHP 8 support, now by default all projects will be parsed as **PHP 8**. If your project uses the `real` cast, the `is_real` function or comments like `#[...`, then use the `--php7` flag to make the analyzer parse the project like PHP 7.4.
+
+### Added
+
+- [#19](https://github.com/VKCOM/nocolor/pull/19): Added initial support of PHP 8
+- [#19](https://github.com/VKCOM/nocolor/pull/19): Added flag `--php7` for analyze as PHP 7
+
+### Changed
+
+- [#19](https://github.com/VKCOM/nocolor/pull/19): Moved to new version of NoVerify:
+  - PHP 8 and 8.1 initial support
+  - Minor improvements in type inference for `instanceof`
+  - Help now has grouping for flags
+
+
 ## `1.0.4` 2021-01-07
 
 > If you used version **1.0.3** and below, then remove the current cache with the `cache-clear` command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ## Unreleased
 
-Due to the addition of PHP 8 support, now by default all projects will be parsed as **PHP 8**. If your project uses the `real` cast, the `is_real` function or comments like `#[...`, then use the `--php7` flag to make the analyzer parse the project like PHP 7.4.
+Due to the addition of PHP 8 support, now by default all projects will be parsed as **PHP 8**. If your project uses the `real` cast, the `is_real` function, comments like `#[...` or `match` and `enum` keywords, then use the `--php7` flag to make the analyzer parse the project like PHP 7.4.
+
+Previously, in order to take into account the `vendor` folder for better type inference, it was necessary to use the `--index-only-files` flag, now the `vendor` folder is added to this flag by default if it exists, so you no longer need to explicitly pass it.
 
 ### Added
 
@@ -15,8 +17,9 @@ Due to the addition of PHP 8 support, now by default all projects will be parsed
 
 - [#19](https://github.com/VKCOM/nocolor/pull/19): Moved to new version of NoVerify:
   - PHP 8 and 8.1 initial support
-  - Minor improvements in type inference for `instanceof`
+  - Improvements in type inference (`instanceof`, `callable` in PHPDoc, `array{}`)
   - Help now has grouping for flags
+  - `vendor` folder is now added by default if it exists
 
 
 ## `1.0.4` 2021-01-07

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -40,7 +40,7 @@ func Check(ctx *cmd.AppContext, globalContext *walkers.GlobalContext) (status in
 	}
 
 	// The main function for analyzing in NoVerify,
-	// in it we collect all the functions of the project.
+	// in it, we collect all the functions of the project.
 	_, err = cmd.Check(ctx)
 	if len(LinterReports) != 0 {
 		HandleShowLinterReports(ctx, LinterReports)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,6 +2,15 @@
 
 This page is dedicated to some technical details.
 
+## How to parse as PHP 7
+
+It looks like this:
+
+```bash
+nocolor check --php7 ./src
+```
+
+By default, all code is parsed as PHP 8, however, some projects use names that have become reserved in PHP 8, so they need to be parsed as PHP 7.
 
 ## How to exclude some folders from checking
 
@@ -16,7 +25,10 @@ The `--index-only-files` option sets paths that won't be analyzed, they will be 
 
 ## How to include the `vendor` folder
 
+>  Since version 1.1, the `vendor` folder is added by default if it exists.
+
 Using the same option:
+
 ```bash
 nocolor check --index-only-files='./vendor' ./src
 ```

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/vkcom/nocolor
 go 1.16
 
 require (
-	github.com/VKCOM/noverify v0.3.1-0.20210630212848-6a7e948f7581
+	github.com/VKCOM/noverify v0.4.1-0.20210820112310-17cd2560f7a0
 	github.com/i582/cfmt v1.3.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
-github.com/VKCOM/noverify v0.3.1-0.20210630212848-6a7e948f7581 h1:MQ+VZYed8J0Ocd0tgqFNsjaPI8S0ueObTHX3wrLExOA=
-github.com/VKCOM/noverify v0.3.1-0.20210630212848-6a7e948f7581/go.mod h1:g0IgAUfjZ9Z3v+nKj+jRyBnBiWHE3O8f7ZLrRlVHk+k=
+github.com/VKCOM/noverify v0.4.1-0.20210820112310-17cd2560f7a0 h1:Wn6Rf+DdoOPRpODjVSfQqMTvQM7DAkRkJXvepB6c0GY=
+github.com/VKCOM/noverify v0.4.1-0.20210820112310-17cd2560f7a0/go.mod h1:4YqmJFxSi6Hw7kBiUZ7GzeQgqHLyxEopsSVhIf9/htA=
+github.com/VKCOM/php-parser v0.8.0-rc.2.0.20210802093708-d85f5a481602 h1:FYasGDmh13Lr5zwqIkxoYZsr/YlEIMTIpqzIu/syeYY=
+github.com/VKCOM/php-parser v0.8.0-rc.2.0.20210802093708-d85f5a481602/go.mod h1:wLtaD4M5K8bJPwjkl4BVone8dbMiG1OApbMKdjubCEw=
 github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
@@ -11,8 +13,6 @@ github.com/gookit/color v1.3.2 h1:WO8+16ZZtx+HlOb6cueziUAF8VtALZKRr/jOvuDk0X0=
 github.com/gookit/color v1.3.2/go.mod h1:R3ogXq2B9rTbXoSHJ1HyUVAZ3poOJHpd9nQmyGZsfvQ=
 github.com/i582/cfmt v1.3.0 h1:UQWMxXt5+iAAtWLD8XUjjGcHCvLM2tRjarvUQs6Ij5o=
 github.com/i582/cfmt v1.3.0/go.mod h1:tpHWAxhE4Y7yy7sliaNe0pnnEs1SZe67KLljyOlEYI8=
-github.com/karrick/godirwalk v1.15.6 h1:Yf2mmR8TJy+8Fa0SuQVto5SYap6IF7lNVX4Jdl8G1qA=
-github.com/karrick/godirwalk v1.15.6/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/2gBQ3RWajuToeY6ZtZTIKv2v7ThUy5KKusIT0yc0=
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -26,8 +26,6 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/yookoala/realpath v1.0.0/go.mod h1:gJJMA9wuX7AcqLy1+ffPatSCySA1FQ2S8Ya9AIoYBpE=
-github.com/z7zmey/php-parser v0.8.0-rc.1.0.20210213215434-367eff9de651 h1:gDfdOvHmWWFqE/LltouUfWGq7Z3PvR4OoOr3ZRwa9J4=
-github.com/z7zmey/php-parser v0.8.0-rc.1.0.20210213215434-367eff9de651/go.mod h1:aae81kYAwd9gCu7qaA7neWjT77MIRtjPqpkXFzSkKIQ=
 go.lsp.dev/uri v0.3.0/go.mod h1:P5sbO1IQR+qySTWOCnhnK7phBx+W3zbLqSMDJNTw88I=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/linttest/linttest.go
+++ b/internal/linttest/linttest.go
@@ -34,7 +34,7 @@ type Suite struct {
 
 // NewSuite returns a new linter test suite for t.
 func NewSuite(t testing.TB) *Suite {
-	conf := linter.NewConfig()
+	conf := linter.NewConfig("8.1")
 	return &Suite{
 		t:      t,
 		config: conf,

--- a/internal/walkers/block_checker.go
+++ b/internal/walkers/block_checker.go
@@ -46,6 +46,8 @@ func (b *BlockChecker) AfterEnterNode(n ir.Node) {
 		b.root.handleStaticCall(n, b.ctx.Scope())
 	case *ir.MethodCallExpr:
 		b.root.handleMethodCall(n, b.ctx.Scope(), b)
+	case *ir.NullsafeMethodCallExpr:
+		b.root.handleNullsafeMethodCall(n, b.ctx.Scope(), b)
 	case *ir.ImportExpr:
 		b.root.handleImportExpr(n)
 	case *ir.CloneExpr:

--- a/tests/edges/php8_test.go
+++ b/tests/edges/php8_test.go
@@ -1,0 +1,44 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/vkcom/nocolor/internal/linttest"
+)
+
+func TestPHP8NullsafeMethodCall(t *testing.T) {
+	suite := linttest.NewSuite(t)
+
+	suite.Palette = defaultPalette
+	suite.AddFile(`<?php
+<?php
+
+class Foo {
+    /**
+     * @color red
+     */
+    public function f() {}
+}
+
+/**
+ * @color green
+ */
+function f($cond) {
+    $a = new Foo;
+    if ($cond) {
+        $a = null;
+    }
+    $a?->f();
+}
+`)
+
+	suite.Expect = []string{
+		`
+green red => calling red from green is prohibited
+  This color rule is broken, call chain:
+f@green -> Foo::f@red
+`,
+	}
+
+	suite.RunAndMatch()
+}

--- a/tests/edges/php8_test.go
+++ b/tests/edges/php8_test.go
@@ -11,8 +11,6 @@ func TestPHP8NullsafeMethodCall(t *testing.T) {
 
 	suite.Palette = defaultPalette
 	suite.AddFile(`<?php
-<?php
-
 class Foo {
     /**
      * @color red


### PR DESCRIPTION
**Type**: `feature`

At the moment we are correctly parsing all PHP 8 and 8.1
except intersection types.

A nullsafe method call is treated like a normal method
call and creates a link.

PHP 8 is now by default. In order to parse the project as
PHP 7, added the `--php7` flag.